### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,4 +1,6 @@
 name: Pylint
+permissions:
+  contents: read
 on:
   push:
     paths:
@@ -6,7 +8,6 @@ on:
       - '*.py'
       - 'requirements.txt'
       - 'pylintrc'
-
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/oliverl-21/Open_PnP_Server/security/code-scanning/2](https://github.com/oliverl-21/Open_PnP_Server/security/code-scanning/2)

To fix the issue, add a `permissions` block at the root level of the workflow file. This block will explicitly set the permissions for the `GITHUB_TOKEN` to `contents: read`, which is sufficient for the workflow's needs. This ensures that the workflow has the minimum required permissions and avoids granting unnecessary write access.

The `permissions` block should be added immediately after the `name` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
